### PR TITLE
修正js如果在head中引入，则取不到body的bug

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -441,6 +441,6 @@
         modalButtonOk: '确定',
         modalButtonCancel: '取消',
         modalPreloaderTitle: '加载中',
-        modalContainer : document.body
+        modalContainer : document.body ? document.body : 'body'
     };
 }(Zepto);


### PR DESCRIPTION
如果sm.js或modal.js是在head中引入的，modalContainer指向的 document.body 则会取成 null。
多加一个判断，在保证后期速度的同时可以保证取到正确的 modalContainer
